### PR TITLE
[Feat/#4] 언어 레벨테스트 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // fluent.me 사용 (음성인식)
+    implementation 'com.google.cloud:google-cloud-storage:2.28.0' // google bucket 사용
 }
 
 tasks.named('test') {

--- a/src/main/java/com/nexus/seoulmate/config/FluentApiProperties.java
+++ b/src/main/java/com/nexus/seoulmate/config/FluentApiProperties.java
@@ -1,21 +1,16 @@
 package com.nexus.seoulmate.config;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+@Getter
+@Setter // Fixme : setter 사용 안할 수 있는 방법 있는지 ...
 @Component
 @ConfigurationProperties(prefix = "fluent.api")
 public class FluentApiProperties {
     private String key;
     private String username;
     private String password;
-
-    public String getKey() { return key; }
-    public void setKey(String key) { this.key = key; }
-
-    public String getUsername() { return username; }
-    public void setUsername(String username) { this.username = username; }
-
-    public String getPassword() { return password; }
-    public void setPassword(String password) { this.password = password; }
 }

--- a/src/main/java/com/nexus/seoulmate/config/FluentApiProperties.java
+++ b/src/main/java/com/nexus/seoulmate/config/FluentApiProperties.java
@@ -1,0 +1,21 @@
+package com.nexus.seoulmate.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "fluent.api")
+public class FluentApiProperties {
+    private String key;
+    private String username;
+    private String password;
+
+    public String getKey() { return key; }
+    public void setKey(String key) { this.key = key; }
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+}

--- a/src/main/java/com/nexus/seoulmate/config/RestTemplateConfig.java
+++ b/src/main/java/com/nexus/seoulmate/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package com.nexus.seoulmate.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/nexus/seoulmate/domain/member/MemberController.java
+++ b/src/main/java/com/nexus/seoulmate/domain/member/MemberController.java
@@ -1,4 +1,0 @@
-package com.nexus.seoulmate.domain.member;
-
-public class MemberController {
-}

--- a/src/main/java/com/nexus/seoulmate/domain/member/controller/FluentProxyController.java
+++ b/src/main/java/com/nexus/seoulmate/domain/member/controller/FluentProxyController.java
@@ -2,10 +2,12 @@ package com.nexus.seoulmate.domain.member.controller;
 
 import com.nexus.seoulmate.domain.member.domain.enums.Languages;
 import com.nexus.seoulmate.domain.member.service.FluentProxyService;
+import com.nexus.seoulmate.exception.Response;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import static com.nexus.seoulmate.exception.status.SuccessStatus.LEVEL_TEST_SUCCESS;
 
 @RestController
 @RequestMapping()
@@ -15,9 +17,9 @@ public class FluentProxyController {
     private final FluentProxyService fluentProxyService;
 
     @GetMapping("/signup/language/level-test")
-    public ResponseEntity<String> testFluentFlow(@RequestPart("audioFile") MultipartFile audioFile,
-                                                 @RequestParam("language") Languages language) {
+    public Response<String> testFluentFlow(@RequestPart("audioFile") MultipartFile audioFile,
+                                           @RequestParam("language") Languages language) {
         String result = fluentProxyService.fluentFlow(audioFile, language);
-        return ResponseEntity.ok(result);
+        return Response.success(LEVEL_TEST_SUCCESS, result);
     }
 }

--- a/src/main/java/com/nexus/seoulmate/domain/member/controller/FluentProxyController.java
+++ b/src/main/java/com/nexus/seoulmate/domain/member/controller/FluentProxyController.java
@@ -1,0 +1,23 @@
+package com.nexus.seoulmate.domain.member.controller;
+
+import com.nexus.seoulmate.domain.member.domain.enums.Languages;
+import com.nexus.seoulmate.domain.member.service.FluentProxyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping()
+@RequiredArgsConstructor
+public class FluentProxyController {
+
+    private final FluentProxyService fluentProxyService;
+
+    @GetMapping("/signup/language/level-test")
+    public ResponseEntity<String> testFluentFlow(@RequestPart("audioFile") MultipartFile audioFile,
+                                                 @RequestParam("language") Languages language) {
+        String result = fluentProxyService.fluentFlow(audioFile, language);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/nexus/seoulmate/domain/member/controller/MemberController.java
+++ b/src/main/java/com/nexus/seoulmate/domain/member/controller/MemberController.java
@@ -1,0 +1,8 @@
+package com.nexus.seoulmate.domain.member.controller;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class MemberController {
+
+}

--- a/src/main/java/com/nexus/seoulmate/domain/member/service/FluentProxyService.java
+++ b/src/main/java/com/nexus/seoulmate/domain/member/service/FluentProxyService.java
@@ -1,0 +1,208 @@
+package com.nexus.seoulmate.domain.member.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexus.seoulmate.config.FluentApiProperties;
+import com.nexus.seoulmate.domain.member.domain.enums.Languages;
+import org.springframework.http.*;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+import com.google.cloud.storage.*;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class FluentProxyService {
+    private final Storage storage = StorageOptions.getDefaultInstance().getService();
+    private final RestTemplate restTemplate;
+    private final FluentApiProperties fluentApiProperties;
+
+    public FluentProxyService(RestTemplate restTemplate, FluentApiProperties fluentApiProperties) {
+        this.restTemplate = restTemplate;
+        this.fluentApiProperties = fluentApiProperties;
+    }
+
+    public String fluentFlow(MultipartFile audioFile, Languages language){
+        System.out.println(storage.getOptions().getProjectId());
+
+        // 1. 로그인
+        String apiKey = fluentApiProperties.getKey();
+        String username = fluentApiProperties.getUsername();
+        String password = fluentApiProperties.getPassword();
+        String xAccessToken = getAccessToken(apiKey, username, password);
+
+        // 2. 음성 파일 제출
+        String postId = null;
+        switch (language){
+            case KOREAN -> postId = "P_Korean";
+            case ENGLISH -> postId = "P555324012"; // 영어 버전
+        }
+
+        // 3. 오디오파일 업로드
+        String bucketName = "bucket-seoulmate-250826";
+        String bucketFolderName = "example-folder";
+
+        // String audioUrl = "https://storage.googleapis.com/bucket-seoulmate-250826/example-folder/english-89.wav";
+        String audioUrl = uploadAudioFile(audioFile, bucketName, bucketFolderName);
+
+        // 4. 채점 요청 및 결과 받기
+        String result = getScore(xAccessToken, postId, audioUrl);
+        // Todo : 이걸 회원가입 dto 에 저장하기
+
+        return result;
+    }
+
+    // 1. 로그인
+    public String getAccessToken(String apiKey, String username, String password){
+        String url = "https://thefluent.me/api/swagger/login";
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("x-api-key", apiKey);
+        headers.setBasicAuth(username, password);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                request,
+                String.class
+        );
+
+        // JSON 응답에서 토큰만 추출
+        String jsonResponse = response.getBody();
+        return extractTokenFromJson(jsonResponse);
+    }
+
+    // JSON 에서 토큰 추출
+    private String extractTokenFromJson(String jsonResponse) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.readTree(jsonResponse);
+            
+            if (root.has("token")) {
+                return root.get("token").asText();
+            }
+            
+            throw new RuntimeException("토큰을 찾을 수 없습니다: " + jsonResponse);
+        } catch (Exception e) {
+            throw new RuntimeException("토큰 파싱 실패: " + jsonResponse, e);
+        }
+    }
+
+    // 2. 포스트 등록
+    private String createPost(String token, String postLanguageId, String postTitle, String postContent){
+        String url = "https://thefluent.me/api/swagger/post";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("x-access-token", token);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("post_language_id", postLanguageId);
+        body.put("post_title", postTitle);
+        body.put("post_content", postContent);
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                url,
+                request,
+                String.class
+        );
+        return response.getBody();
+    }
+
+    // 3. 포스트 조회
+    public String getAllPosts(String token, Integer page, Integer perPage) {
+        String url = "https://thefluent.me/api/swagger/post"; // 실제 엔드포인트
+        if (page != null || perPage != null) {
+            StringBuilder sb = new StringBuilder(url);
+            sb.append("?");
+            if (page != null) sb.append("page=").append(page).append("&");
+            if (perPage != null) sb.append("per_page=").append(perPage);
+            url = sb.toString().replaceAll("&$", "");
+        }
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("x-access-token", token);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                request,
+                String.class
+        );
+        return response.getBody();
+    }
+
+    // 4. 오디오 파일 버킷에 업로드
+    public String uploadAudioFile(MultipartFile audioFile, String bucketName, String bucketFolderName){
+        String fileName = bucketFolderName + "/" + UUID.randomUUID() + ".wav";
+        BlobId blobId = BlobId.of(bucketName, fileName);
+        BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("audio/wav").build();
+
+        try {
+            storage.create(blobInfo, audioFile.getBytes()); // 파일 업로드
+            // storage.createAcl(blobId, Acl.of(Acl.User.ofAllUsers(), Acl.Role.READER)); // 파일에 공개 권한 부여
+            return "https://storage.googleapis.com/" + bucketName + "/" + fileName;
+        } catch (IOException e){
+            throw new RuntimeException("GCS 업로드 실패", e);
+        }
+    }
+
+    // 5. 음성 파일 제출하기 (결과 얻기) - POST /swagger/score/{post_id}
+    public String getScore(String token, String postId, String audioUrl){
+        String url = "https://thefluent.me/api/swagger/score/" + postId;
+        
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("x-access-token", token);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("audio_provided", audioUrl);
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                url,
+                request,
+                String.class
+        );
+        
+        // JSON 응답에서 overall_points만 추출
+        String jsonResponse = response.getBody();
+        return extractOverallPointsFromJson(jsonResponse);
+        // return response.getBody(); <- 기존 전체 결과 불러오기
+    }
+
+    // JSON에서 overall_points 추출
+    private String extractOverallPointsFromJson(String jsonResponse) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.readTree(jsonResponse);
+
+            // overall_result_data 배열에서 첫 번째 객체의 overall_points 추출
+            for (JsonNode node : root) {
+                if (node.has("overall_result_data")) {
+                    JsonNode overallResultData = node.get("overall_result_data");
+                    if (overallResultData.isArray() && overallResultData.size() > 0) {
+                        JsonNode firstResult = overallResultData.get(0);
+                        if (firstResult.has("overall_points")) {
+                            return firstResult.get("overall_points").asText();
+                        }
+                    }
+                }
+            }
+
+            throw new RuntimeException("overall_points를 찾을 수 없습니다: " + jsonResponse);
+        } catch (Exception e) {
+            throw new RuntimeException("overall_points 파싱 실패: " + jsonResponse, e);
+        }
+    }
+}

--- a/src/main/java/com/nexus/seoulmate/exception/status/ErrorStatus.java
+++ b/src/main/java/com/nexus/seoulmate/exception/status/ErrorStatus.java
@@ -14,9 +14,22 @@ public enum ErrorStatus {
     FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "찾을 수 없는 리소스입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "사용자를 찾을 수 없습니다"),
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON405", "허용되지 않는 HTTP Method입니다.");
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON405", "허용되지 않는 HTTP Method입니다."),
 
     // 도메인별로
+    // Member
+    // Fluent 관련 예외
+    FLUENT_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "FLUENT 401", "Fluent API 로그인에 실패했습니다."),
+    FLUENT_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "FLUENT 404", "Fluent API 토큰을 찾을 수 없습니다."),
+    FLUENT_TOKEN_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FLUENT 500", "Fluent API 토큰 파싱에 실패했습니다."),
+    POST_CREATE_FAILED(HttpStatus.BAD_REQUEST, "FLUENT 400", "Fluent API 게시물 생성에 실패했습니다."),
+    GET_POSTS_FAILED(HttpStatus.BAD_REQUEST, "FLUENT 400", "Fluent API 게시물 조회에 실패했습니다."),
+    // FLUENT_SCORE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FLUENT 500", "Fluent API 채점 요청에 실패했습니다."),
+    FLUENT_RESULT_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FLUENT 500", "Fluent API 채점 결과 파싱에 실패했습니다."),
+    FLUENT_AUDIO_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FLUENT 500", "음성 파일 업로드에 실패했습니다."),
+    FLUENT_OVERALL_POINT_NOT_FOUND(HttpStatus.NOT_FOUND, "FLUENT 404", "overall_points를 찾을 수 없습니다."),
+    FLUENT_OVERALL_POINT_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FLUENT 500", "overall_points 파싱에 실패했습니다.");
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/nexus/seoulmate/exception/status/SuccessStatus.java
+++ b/src/main/java/com/nexus/seoulmate/exception/status/SuccessStatus.java
@@ -9,9 +9,11 @@ import org.springframework.http.HttpStatus;
 public enum SuccessStatus {
     // SUCCESS 2XX
     SUCCESS(HttpStatus.OK, "COMMON200", "요청이 성공적으로 처리되었습니다."),
-    CREATED(HttpStatus.CREATED, "COMMON201", "리소스가 성공적으로 생성되었습니다.");
+    CREATED(HttpStatus.CREATED, "COMMON201", "리소스가 성공적으로 생성되었습니다."),
 
     // 도메인별로
+    // 회원가입
+    LEVEL_TEST_SUCCESS(HttpStatus.OK, "SIGNUP 200", "레벨테스트 성공했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/nexus/seoulmate/mock/HobbyDataInitializer.java
+++ b/src/main/java/com/nexus/seoulmate/mock/HobbyDataInitializer.java
@@ -41,8 +41,11 @@ public class HobbyDataInitializer {
                             .hobbyName(hobbyName)
                             .hobbyCategory(category)
                             .build());
+                    System.out.println("취미 리스트 생성 완료");
+                } else {
+                    System.out.println("취미 리스트가 이미 존재합니다.");
                 }
-            } System.out.println("취미 리스트 생성 완료");
+            }
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,9 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type.descriptor.sql: trace
+
+fluent:
+  api:
+    key: ${fluent.api.key}
+    username: ${fluent.api.username}
+    password: ${fluent.api.password}


### PR DESCRIPTION
### 이슈 번호
> #4 

### 작업 내용
* fluent.me api 사용
* -> 로그인, 포스트(스크립트) 등록, 포스트 조회, 음성파일 업로드, 음성 검사 결과 조회 구현


### 기타
* 회원가입 구현할 때 레벨테스트 로직 합쳐야 함
* 스크립트 생성 후 포스트 아이디 넣어야 함