### PR TITLE
[Feat/#58] 채팅 api 관련 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,11 +49,25 @@ dependencies {
 
     // PortOne (결제)
     implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
+    //  implementation files(
+    //       'libs/iamport-rest-client-java-0.2.23.jar',
+    //       'libs/retrofit-2.9.0.jar',
+    //       'libs/converter-gson-2.9.0.jar',
+    //       'libs/okhttp-3.14.9.jar',
+    //       'libs/gson-2.8.9.jar',
+    //       'libs/okio-1.17.2.jar'
+    //  )
 
     // redis 사용
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    //implementation 'org.springframework.session:spring-session-data-redis'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'org.apache.commons:commons-pool2'
+    // implementation files('/libs/commons-pool2-2.11.1.jar')
+
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/nexus/seoulmate/chat/api/ChatController.java
+++ b/src/main/java/com/nexus/seoulmate/chat/api/ChatController.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -97,4 +96,17 @@ public class ChatController {
         var header = chatService.getRoomHeader(roomId);
         return ResponseEntity.ok(Response.success(SuccessStatus.CHAT_ROOM_FETCHED, header));
     }
+
+    @PostMapping("/group/join")
+    @Operation(
+            summary = "사설모임 그룹 채팅 합류",
+            description = "meetingId로 연결된 그룹 채팅방에 현재 사용자를 멤버로 추가합니다. 이미 멤버인 경우 idempotent하게 방 요약을 반환합니다."
+    )
+    public ResponseEntity<Response<ChatRoomDTO.RoomSummary>> joinGroup(
+            @RequestBody ChatRoomDTO.GroupJoinRequest req
+    ) {
+        ChatRoomDTO.RoomSummary summary = chatService.joinGroupRoom(req);
+        return ResponseEntity.ok(Response.success(SuccessStatus.CHAT_ROOM_JOINED, summary));
+    }
+
 }

--- a/src/main/java/com/nexus/seoulmate/chat/api/ChatController.java
+++ b/src/main/java/com/nexus/seoulmate/chat/api/ChatController.java
@@ -1,0 +1,100 @@
+package com.nexus.seoulmate.chat.api;
+
+import com.nexus.seoulmate.chat.application.ChatService;
+import com.nexus.seoulmate.chat.dto.ChatRoomDTO;
+import com.nexus.seoulmate.chat.dto.MessageDTO;
+import com.nexus.seoulmate.exception.Response;
+import com.nexus.seoulmate.exception.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/chat")
+@RequiredArgsConstructor
+@Tag(name = "Chat", description = "채팅 관련 API")
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @PostMapping("/room/onetoone")
+    @Operation(
+            summary = "1:1 채팅방 생성",
+            description = "me ↔ partnerUserId 조합으로 DIRECT 방을 생성합니다."
+    )
+    public ResponseEntity<Response<ChatRoomDTO.RoomSummary>> createDirectRoom(
+            @RequestBody ChatRoomDTO.DirectCreateRequest request
+    ) {
+        ChatRoomDTO.RoomSummary result = chatService.createDirectRoom(request);
+        return ResponseEntity.ok(Response.success(SuccessStatus.CHAT_ROOM_CREATED, result));
+    }
+
+    @PostMapping("/room/group")
+    @Operation(
+            summary = "그룹 채팅방 생성",
+            description = "현재 로그인 사용자를 OWNER로, 전달된 사용자들을 PARTICIPANT로 추가하여 GROUP 방을 생성합니다."
+    )
+    public ResponseEntity<Response<ChatRoomDTO.RoomSummary>> createGroupRoom(
+            @RequestBody ChatRoomDTO.GroupCreateRequest request
+    ) {
+        var result = chatService.createGroupRoom(request);
+        return ResponseEntity.ok(Response.success(SuccessStatus.CHAT_ROOM_CREATED, result));
+    }
+
+    @GetMapping("/rooms")
+    @Operation(
+            summary = "내 채팅방 목록 조회",
+            description = "현재 로그인 사용자가 속한 채팅방 목록을 반환합니다. type은 미지정(전체) 또는 DIRECT | GROUP 만 허용합니다. page/size는 페이지네이션."
+    )
+    public ResponseEntity<Response<List<ChatRoomDTO.RoomListItem>>> getMyRooms(
+            @Parameter(description = "DIRECT | GROUP") @RequestParam(required = false) String type,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        var results = chatService.getMyRooms(type, page, size);
+        return ResponseEntity.ok(Response.success(SuccessStatus.CHAT_ROOMS_FETCHED, results));
+    }
+
+    @PostMapping("/rooms/{roomId}/messages")
+    @Operation(
+            summary = "메시지 전송",
+            description = "DB에 저장 후 Redis로 발행하여 STOMP로 브로드캐스트합니다. (MessageDTO.Sent 단일 DTO)"
+    )
+    public ResponseEntity<Response<MessageDTO.Sent>> sendMessage(
+            @PathVariable Long roomId,
+            @RequestBody MessageDTO.SendRequest request
+    ) {
+        var result = chatService.sendMessage(roomId, request);
+        return ResponseEntity.ok(Response.success(SuccessStatus.CHAT_MESSAGE_SENT, result));
+    }
+
+    @GetMapping("/rooms/{roomId}/messages")
+    @Operation(
+            summary = "채팅 메시지 조회 (커서 기반)",
+            description = "cursor 미지정 시 최신 N개, cursor 제공 시 해당 id보다 과거 메시지를 size만큼 반환합니다. 반환은 오래된→최신 순으로 정렬됩니다."
+    )
+    public ResponseEntity<Response<MessageDTO.Page>> getMessages(
+            @PathVariable Long roomId,
+            @Parameter(description = "이 id보다 오래된 메시지(과거) 조회") @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "30") int size
+    ) {
+        var page = chatService.getMessages(roomId, cursor, size);
+        return ResponseEntity.ok(Response.success(SuccessStatus.CHAT_MESSAGES_FETCHED, page));
+    }
+
+    @GetMapping("/rooms/{roomId}/header")
+    @Operation(
+            summary = "채팅방 헤더 정보 조회",
+            description = "DIRECT는 상대 이름을 title로, GROUP은 방 제목과 함께 참여자 전원의 이름/프로필 이미지를 반환합니다."
+    )
+    public ResponseEntity<Response<ChatRoomDTO.RoomHeader>> getRoomHeader(@PathVariable Long roomId) {
+        var header = chatService.getRoomHeader(roomId);
+        return ResponseEntity.ok(Response.success(SuccessStatus.CHAT_ROOM_FETCHED, header));
+    }
+}

--- a/src/main/java/com/nexus/seoulmate/chat/application/ChatService.java
+++ b/src/main/java/com/nexus/seoulmate/chat/application/ChatService.java
@@ -12,4 +12,5 @@ public interface ChatService {
     MessageDTO.Sent sendMessage(Long roomId, MessageDTO.SendRequest req);
     MessageDTO.Page getMessages(Long roomId, Long cursor, int size);
     ChatRoomDTO.RoomHeader getRoomHeader(Long roomId);
+    ChatRoomDTO.RoomSummary joinGroupRoom(ChatRoomDTO.GroupJoinRequest req);
 }

--- a/src/main/java/com/nexus/seoulmate/chat/application/ChatService.java
+++ b/src/main/java/com/nexus/seoulmate/chat/application/ChatService.java
@@ -1,0 +1,15 @@
+package com.nexus.seoulmate.chat.application;
+
+import com.nexus.seoulmate.chat.dto.ChatRoomDTO;
+import com.nexus.seoulmate.chat.dto.MessageDTO;
+
+import java.util.List;
+
+public interface ChatService {
+    ChatRoomDTO.RoomSummary createDirectRoom(ChatRoomDTO.DirectCreateRequest req);
+    ChatRoomDTO.RoomSummary createGroupRoom(ChatRoomDTO.GroupCreateRequest req);
+    List<ChatRoomDTO.RoomListItem> getMyRooms(String type, int page, int size);
+    MessageDTO.Sent sendMessage(Long roomId, MessageDTO.SendRequest req);
+    MessageDTO.Page getMessages(Long roomId, Long cursor, int size);
+    ChatRoomDTO.RoomHeader getRoomHeader(Long roomId);
+}

--- a/src/main/java/com/nexus/seoulmate/chat/application/ChatServiceImpl.java
+++ b/src/main/java/com/nexus/seoulmate/chat/application/ChatServiceImpl.java
@@ -1,0 +1,345 @@
+package com.nexus.seoulmate.chat.application;
+
+import com.nexus.seoulmate.chat.converter.ChatConverter;
+import com.nexus.seoulmate.chat.domain.entity.*;
+import com.nexus.seoulmate.chat.domain.repository.ChatRoomMemberRepository;
+import com.nexus.seoulmate.chat.domain.repository.ChatRoomRepository;
+import com.nexus.seoulmate.chat.domain.repository.MessageRepository;
+import com.nexus.seoulmate.chat.dto.ChatRoomDTO;
+import com.nexus.seoulmate.chat.dto.MessageDTO;
+import com.nexus.seoulmate.chat.event.ChatEvents;
+import com.nexus.seoulmate.chat.redis.ChatPublisher;
+import com.nexus.seoulmate.exception.CustomException;
+import com.nexus.seoulmate.exception.status.ErrorStatus;
+import com.nexus.seoulmate.meeting.domain.Meeting;
+import com.nexus.seoulmate.meeting.domain.MeetingType;
+import com.nexus.seoulmate.meeting.domain.repository.MeetingRepository;
+import com.nexus.seoulmate.member.domain.Member;
+import com.nexus.seoulmate.member.repository.MemberRepository;
+import com.nexus.seoulmate.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ChatServiceImpl implements ChatService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final MessageRepository messageRepository;
+    private final MemberRepository memberRepository;
+    private final MemberService memberService;
+    private final ChatConverter chatConverter;
+    private final ChatPublisher chatPublisher;
+    private final ApplicationEventPublisher publisher;
+    private final MeetingRepository meetingRepository;
+
+    @Override
+    @Transactional
+    public ChatRoomDTO.RoomSummary createDirectRoom(ChatRoomDTO.DirectCreateRequest req) {
+        Member member = memberService.getCurrentUser();
+        Long meId = member.getUserId();
+
+        Long partnerId = req.getPartnerUserId();
+        if (partnerId == null || partnerId <= 0 || partnerId.equals(meId)) {
+            throw new CustomException(ErrorStatus.CHAT_INVALID_PARTNER);
+        }
+
+        Member partner = memberRepository.findById(partnerId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.USER_NOT_FOUND));
+
+        String partnerFullName = chatConverter.formatName(partner);
+
+        ChatRoom room = ChatRoom.builder()
+                .type(RoomType.DIRECT)
+                .title(partnerFullName)
+                .chatImage(partner.getProfileImage())
+                .build();
+        chatRoomRepository.save(room);
+
+        chatRoomMemberRepository.save(ChatRoomMember.builder()
+                .roomId(room.getId()).userId(meId).role(Role.PARTICIPANT).build());
+        chatRoomMemberRepository.save(ChatRoomMember.builder()
+                .roomId(room.getId()).userId(partnerId).role(Role.PARTICIPANT).build());
+
+        List<ChatRoomMember> members = chatRoomMemberRepository.findByRoomId(room.getId());
+        Map<Long, Member> userMap = memberRepository.findAllById(
+                members.stream().map(ChatRoomMember::getUserId).toList()
+        ).stream().collect(Collectors.toMap(Member::getUserId, m -> m));
+
+        List<ChatRoomDTO.Participant> participants = members.stream()
+                .map(cm -> chatConverter.toParticipant(
+                        userMap.get(cm.getUserId()),
+                        cm.getUserId(),
+                        cm.getRole().name(),
+                        cm.getUserId().equals(meId)
+                ))
+                .toList();
+
+        return chatConverter.toRoomSummaryDirect(room, meId, participants);
+    }
+
+    @Override
+    @Transactional
+    public ChatRoomDTO.RoomSummary createGroupRoom(ChatRoomDTO.GroupCreateRequest req) {
+        Member me = memberService.getCurrentUser();
+        Long meId = me.getUserId();
+
+        if (req.getMeetingId() == null) {
+            throw new CustomException(ErrorStatus.CHAT_GROUP_MEETING_REQUIRED);
+        }
+        if (req.getMemberUserIds() == null || req.getMemberUserIds().isEmpty()) {
+            throw new CustomException(ErrorStatus.INVALID_PARAMETER);
+        }
+
+        Set<Long> otherIds = new HashSet<>(req.getMemberUserIds());
+        otherIds.remove(meId);
+
+        if (otherIds.size() + 1 < 3) {
+            throw new CustomException(ErrorStatus.CHAT_GROUP_MIN_MEMBERS);
+        }
+
+        for (Long uid : otherIds) {
+            if (uid == null || uid <= 0 || !memberRepository.existsById(uid)) {
+                throw new CustomException(ErrorStatus.USER_NOT_FOUND);
+            }
+        }
+
+        Meeting meeting = meetingRepository.findWithUserById(req.getMeetingId())
+                .orElseThrow(() -> new CustomException(ErrorStatus.CHAT_GROUP_MEETING_NOT_FOUND));
+
+        if (meeting.getMeetingType() != MeetingType.PRIVATE) {
+            throw new CustomException(ErrorStatus.INVALID_MEETING_TYPE);
+        }
+
+        final String title = meeting.getTitle();
+        final String image = meeting.getImage();
+
+        ChatRoom room = ChatRoom.builder()
+                .type(RoomType.GROUP)
+                .title(title)
+                .chatImage(image)
+                .build();
+        chatRoomRepository.save(room);
+
+        List<ChatRoomMember> members = new ArrayList<>();
+        members.add(ChatRoomMember.builder()
+                .roomId(room.getId())
+                .userId(meId)
+                .role(Role.OWNER)
+                .build());
+        for (Long uid : otherIds) {
+            members.add(ChatRoomMember.builder()
+                    .roomId(room.getId())
+                    .userId(uid)
+                    .role(Role.PARTICIPANT)
+                    .build());
+        }
+        chatRoomMemberRepository.saveAll(members);
+
+        List<Long> allUserIds = members.stream()
+                .map(ChatRoomMember::getUserId)
+                .toList();
+        List<Member> userEntities = memberRepository.findAllById(allUserIds);
+        Map<Long, Member> userMap = userEntities.stream()
+                .collect(Collectors.toMap(Member::getUserId, m -> m));
+
+        List<ChatRoomDTO.Participant> participants = members.stream()
+                .map(cm -> {
+                    Member user = userMap.get(cm.getUserId());
+                    return chatConverter.toParticipant(
+                            user,
+                            cm.getUserId(),
+                            cm.getRole().name(),
+                            cm.getUserId().equals(meId)
+                    );
+                })
+                .toList();
+
+        return chatConverter.toRoomSummaryGroup(room, meId, participants);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatRoomDTO.RoomListItem> getMyRooms(String type, int page, int size) {
+        Member me = memberService.getCurrentUser();
+        Long meId = me.getUserId();
+
+        RoomType filter = null;
+        if (type != null && !type.isBlank()) {
+            try {
+                filter = RoomType.valueOf(type.trim().toUpperCase()); // DIRECT | GROUP
+            } catch (IllegalArgumentException e) {
+                throw new CustomException(ErrorStatus.INVALID_PARAMETER);
+            }
+        }
+
+        var pageReq = PageRequest.of(page, Math.min(Math.max(size, 1), 20));
+        var roomsPage = chatRoomRepository.findMyRoomsOrderByLatestMessage(meId, filter, pageReq);
+        List<ChatRoom> rooms = roomsPage.getContent();
+        if (rooms.isEmpty()) return List.of();
+
+        List<Long> roomIds = rooms.stream().map(ChatRoom::getId).toList();
+        Map<Long, Message> latestByRoom = messageRepository.findLatestByRoomIds(roomIds)
+                .stream()
+                .collect(Collectors.toMap(Message::getRoomId, m -> m));
+
+        Map<Long, Long> partnerIdByRoom = new HashMap<>();
+        var directIds = rooms.stream()
+                .filter(r -> r.getType() == RoomType.DIRECT)
+                .map(ChatRoom::getId)
+                .toList();
+
+        if (!directIds.isEmpty()) {
+            var members = chatRoomMemberRepository.findByRoomIdIn(directIds);
+            var grouped = members.stream().collect(Collectors.groupingBy(ChatRoomMember::getRoomId));
+            for (Long rid : directIds) {
+                var list = grouped.getOrDefault(rid, List.of());
+                list.stream()
+                        .filter(mb -> !Objects.equals(mb.getUserId(), meId))
+                        .findFirst()
+                        .ifPresent(mb -> partnerIdByRoom.put(rid, mb.getUserId()));
+            }
+        }
+
+        Map<Long, String> nameByUser = new HashMap<>();
+        if (!partnerIdByRoom.isEmpty()) {
+            List<Long> pIds = new ArrayList<>(new HashSet<>(partnerIdByRoom.values()));
+            memberRepository.findAllById(pIds).forEach(u -> {
+                String partnerFullName = chatConverter.formatName(u);
+                nameByUser.put(u.getUserId(), partnerFullName);
+            });
+        }
+
+        List<ChatRoomDTO.RoomListItem> results = new ArrayList<>(rooms.size());
+        for (ChatRoom r : rooms) {
+            Message latest = latestByRoom.get(r.getId());
+            if (r.getType() == RoomType.GROUP) {
+                results.add(chatConverter.toListItemGroup(r, latest));
+            } else {
+                Long pid = partnerIdByRoom.get(r.getId());
+                String pname = pid != null ? nameByUser.get(pid) : null;
+                results.add(chatConverter.toListItemDirect(r, pid, pname, latest));
+            }
+        }
+
+        return results;
+    }
+
+    @Transactional
+    public MessageDTO.Sent sendMessage(Long roomId, MessageDTO.SendRequest req) {
+        Member me = memberService.getCurrentUser();
+        Long meId = me.getUserId();
+        String senderName = chatConverter.formatName(me);;
+
+        ChatRoom room = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.CHAT_ROOM_NOT_FOUND));
+
+        if (!chatRoomMemberRepository.existsByRoomIdAndUserId(roomId, meId)) {
+            throw new CustomException(ErrorStatus.CHAT_NOT_MEMBER);
+        }
+
+        if (req.getType() == MsgType.TEXT &&
+                (req.getContent() == null || req.getContent().isBlank())) {
+            throw new CustomException(ErrorStatus.CHAT_EMPTY_MESSAGE);
+        }
+
+        Message message = messageRepository.save(
+                Message.builder()
+                        .roomId(roomId)
+                        .senderId(meId)
+                        .type(req.getType())
+                        .content(req.getContent())
+                        .build()
+        );
+        MessageDTO.Sent sent = chatConverter.toSent(message, senderName);
+
+        publisher.publishEvent(new ChatEvents.MessageSaved(roomId, sent));
+
+        return sent;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MessageDTO.Page getMessages(Long roomId, Long cursor, int size) {
+        Member me = memberService.getCurrentUser();
+        Long meId = me.getUserId();
+
+        // 권한 체크
+        if (!chatRoomMemberRepository.existsByRoomIdAndUserId(roomId, meId)) {
+            throw new CustomException(ErrorStatus.CHAT_NOT_MEMBER);
+        }
+
+        // 최신부터 size개 가져옴 (cursor 없으면 최신 N개)
+        var pageable = PageRequest.of(0, Math.min(Math.max(size, 1), 100),
+                Sort.by(Sort.Direction.DESC, "id"));
+
+        List<Message> desc = messageRepository.findRecent(roomId, cursor, pageable);
+        if (desc.isEmpty()) {
+            return chatConverter.toMessagePage(List.of(), null, false);
+        }
+
+        // 발신자 정보 일괄 조회
+        List<Long> senderIds = desc.stream().map(Message::getSenderId)
+                .distinct().collect(Collectors.toList());
+        Map<Long, Member> senderMap = memberRepository.findAllById(senderIds).stream()
+                .collect(Collectors.toMap(m -> m.getUserId(), m -> m));
+
+        // 변환
+        List<MessageDTO.MessageItem> items = desc.stream()
+                .map(m -> chatConverter.toMessageItem(m, senderMap.get(m.getSenderId()), meId))
+                .collect(Collectors.toList());
+
+        // nextCursor = 현재 응답 중 가장 오래된 메시지 id (desc의 마지막)
+        Long oldestId = desc.get(desc.size() - 1).getId();
+        boolean hasMore = messageRepository.existsByRoomIdAndIdLessThan(roomId, oldestId);
+
+        return chatConverter.toMessagePage(items, oldestId, hasMore);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ChatRoomDTO.RoomHeader getRoomHeader(Long roomId) {
+        Member me = memberService.getCurrentUser();
+        Long meId = me.getUserId();
+
+        ChatRoom room = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.CHAT_ROOM_NOT_FOUND));
+
+        if (!chatRoomMemberRepository.existsByRoomIdAndUserId(roomId, meId)) {
+            throw new CustomException(ErrorStatus.CHAT_NOT_MEMBER);
+        }
+
+        List<ChatRoomMember> members = chatRoomMemberRepository.findByRoomId(roomId);
+        List<Long> uids = members.stream().map(ChatRoomMember::getUserId).toList();
+
+        Map<Long, Member> users = memberRepository.findAllById(uids).stream()
+                .collect(Collectors.toMap(m -> m.getUserId(), m -> m));
+
+        List<ChatRoomDTO.Participant> participants = new ArrayList<>();
+        for (ChatRoomMember m : members) {
+            Member u = users.get(m.getUserId());
+            participants.add(
+                    chatConverter.toParticipant(u, m.getUserId(), m.getRole().name(), Objects.equals(m.getUserId(), meId))
+            );
+        }
+
+        if (room.getType() == RoomType.DIRECT) {
+            Long partnerId = members.stream()
+                    .map(ChatRoomMember::getUserId)
+                    .filter(id -> !Objects.equals(id, meId))
+                    .findFirst()
+                    .orElseThrow(() -> new CustomException(ErrorStatus.CHAT_INVALID_PARTNER));
+            String partnerName = chatConverter.formatName(users.get(partnerId));
+            return chatConverter.toHeaderDirect(room, partnerName, participants);
+        } else {
+            return chatConverter.toHeaderGroup(room, participants);
+        }
+    }
+}

--- a/src/main/java/com/nexus/seoulmate/chat/converter/ChatConverter.java
+++ b/src/main/java/com/nexus/seoulmate/chat/converter/ChatConverter.java
@@ -1,0 +1,160 @@
+package com.nexus.seoulmate.chat.converter;
+
+import com.nexus.seoulmate.chat.domain.entity.ChatRoom;
+import com.nexus.seoulmate.chat.domain.entity.Message;
+import com.nexus.seoulmate.chat.dto.ChatRoomDTO;
+import com.nexus.seoulmate.chat.dto.MessageDTO;
+import com.nexus.seoulmate.member.domain.Member;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class ChatConverter {
+
+    public ChatRoomDTO.RoomSummary toRoomSummaryDirect(ChatRoom room,
+                                                       Long myUserId,
+                                                       List<ChatRoomDTO.Participant> participants) {
+        return ChatRoomDTO.RoomSummary.builder()
+                .roomId(room.getId())
+                .title(room.getTitle())
+                .roomImageUrl(room.getChatImage())
+                .type(room.getType().name()) // "DIRECT"
+                .myUserId(myUserId)
+                .participants(participants)
+                .build();
+    }
+
+    public ChatRoomDTO.RoomSummary toRoomSummaryGroup(ChatRoom room,
+                                                      Long myUserId,
+                                                      List<ChatRoomDTO.Participant> participants) {
+        return ChatRoomDTO.RoomSummary.builder()
+                .roomId(room.getId())
+                .title(room.getTitle())
+                .roomImageUrl(room.getChatImage())
+                .type(room.getType().name()) // "GROUP"
+                .myUserId(myUserId)
+                .participants(participants)
+                .build();
+    }
+
+    public ChatRoomDTO.RoomListItem toListItemGroup(ChatRoom room, Message latest) {
+        return ChatRoomDTO.RoomListItem.builder()
+                .roomId(room.getId())
+                .type(room.getType().name())
+                .title(room.getTitle())
+                .roomImageUrl(room.getChatImage())
+                .partnerUserId(null)
+                .lastMessageType(latest != null ? latest.getType().name() : null)
+                .lastMessage(latest != null ? summarize(latest) : null)
+                .lastMessageAt(latest != null ? latest.getCreatedAt() : null)
+                .build();
+    }
+
+    public ChatRoomDTO.RoomListItem toListItemDirect(ChatRoom room, Long partnerId, String partnerName, Message latest) {
+        return ChatRoomDTO.RoomListItem.builder()
+                .roomId(room.getId())
+                .type(room.getType().name())
+                .title(room.getTitle())
+                .roomImageUrl(room.getChatImage())
+                .partnerUserId(partnerId)
+                .lastMessageType(latest != null ? latest.getType().name() : null)
+                .lastMessage(latest != null ? summarize(latest) : null)
+                .lastMessageAt(latest != null ? latest.getCreatedAt() : null)
+                .build();
+    }
+
+    private String summarize(Message m) {
+        return switch (m.getType()) {
+            case TEXT -> {
+                String c = m.getContent();
+                yield (c != null && c.length() > 60) ? c.substring(0, 60) + "…" : c;
+            }
+            case FILE -> "[파일]";
+            case SYS  -> m.getContent();
+        };
+    }
+
+    public MessageDTO.Sent toSent(Message m, String senderName) {
+        return MessageDTO.Sent.builder()
+                .messageId(m.getId())
+                .roomId(m.getRoomId())
+                .senderId(m.getSenderId())
+                .senderName(senderName)
+                .type(m.getType().name())
+                .content(m.getContent())
+                .createdAt(m.getCreatedAt() != null ? m.getCreatedAt() : LocalDateTime.now())
+                .build();
+    }
+
+    public MessageDTO.MessageItem toMessageItem(Message m, Member sender, Long meId) {
+        return MessageDTO.MessageItem.builder()
+                .messageId(m.getId())
+                .roomId(m.getRoomId())
+                .senderId(m.getSenderId())
+                .senderName(formatName(sender))
+                .senderProfileImageUrl(sender.getProfileImage())
+                .type(m.getType().name())
+                .content(m.getContent())
+                .createdAt(m.getCreatedAt() != null ? m.getCreatedAt() : LocalDateTime.now())
+                .mine(m.getSenderId().equals(meId))
+                .build();
+    }
+
+    public MessageDTO.Page toMessagePage(List<MessageDTO.MessageItem> items, Long nextCursor, boolean hasMore) {
+        List<MessageDTO.MessageItem> asc = items.stream()
+                .sorted((a, b) -> a.getMessageId().compareTo(b.getMessageId()))
+                .collect(Collectors.toList());
+
+        return MessageDTO.Page.builder()
+                .items(asc)
+                .nextCursor(nextCursor)
+                .hasMore(hasMore)
+                .build();
+    }
+
+    public ChatRoomDTO.Participant toParticipant(Member m, Long userId, String role, boolean me) {
+        return ChatRoomDTO.Participant.builder()
+                .userId(userId)
+                .name(formatName(m))
+                .profileImageUrl(m.getProfileImage())
+                .role(role)
+                .me(me)
+                .build();
+    }
+
+    public ChatRoomDTO.RoomHeader toHeaderDirect(ChatRoom room, String partnerName,
+                                                 List<ChatRoomDTO.Participant> participants) {
+        return ChatRoomDTO.RoomHeader.builder()
+                .roomId(room.getId())
+                .type(room.getType().name())
+                .title(partnerName)
+                .roomImageUrl(room.getChatImage())
+                .participants(participants)
+                .build();
+    }
+
+    public ChatRoomDTO.RoomHeader toHeaderGroup(ChatRoom room,
+                                                List<ChatRoomDTO.Participant> participants) {
+        return ChatRoomDTO.RoomHeader.builder()
+                .roomId(room.getId())
+                .type(room.getType().name())
+                .title(room.getTitle())
+                .roomImageUrl(room.getChatImage())
+                .participants(participants)
+                .build();
+    }
+
+    public String formatName(Member member) {
+        switch (member.getCountry()) {
+            case KOREA:
+            case CHINA:
+            case JAPAN:
+                return member.getLastName() + member.getFirstName();
+            default:
+                return member.getFirstName() + " " + member.getLastName();
+        }
+    }
+}

--- a/src/main/java/com/nexus/seoulmate/chat/domain/entity/ChatRoom.java
+++ b/src/main/java/com/nexus/seoulmate/chat/domain/entity/ChatRoom.java
@@ -20,4 +20,6 @@ public class ChatRoom extends BaseEntity {
     private String title;
 
     private String chatImage;
+
+    private Long meetingId;
 }

--- a/src/main/java/com/nexus/seoulmate/chat/domain/entity/ChatRoom.java
+++ b/src/main/java/com/nexus/seoulmate/chat/domain/entity/ChatRoom.java
@@ -1,0 +1,23 @@
+package com.nexus.seoulmate.chat.domain.entity;
+
+import com.nexus.seoulmate.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChatRoom extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private RoomType type;
+
+    private String title;
+
+    private String chatImage;
+}

--- a/src/main/java/com/nexus/seoulmate/chat/domain/entity/ChatRoomMember.java
+++ b/src/main/java/com/nexus/seoulmate/chat/domain/entity/ChatRoomMember.java
@@ -1,0 +1,26 @@
+package com.nexus.seoulmate.chat.domain.entity;
+
+import com.nexus.seoulmate.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChatRoomMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long roomId;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+}

--- a/src/main/java/com/nexus/seoulmate/chat/domain/entity/Message.java
+++ b/src/main/java/com/nexus/seoulmate/chat/domain/entity/Message.java
@@ -1,0 +1,29 @@
+package com.nexus.seoulmate.chat.domain.entity;
+
+import com.nexus.seoulmate.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Message extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long roomId;
+
+    @Column(nullable = false)
+    private Long senderId;
+
+    @Enumerated(EnumType.STRING)
+    private MsgType type;
+
+    @Lob
+    private String content;
+}

--- a/src/main/java/com/nexus/seoulmate/chat/domain/entity/MsgType.java
+++ b/src/main/java/com/nexus/seoulmate/chat/domain/entity/MsgType.java
@@ -1,0 +1,5 @@
+package com.nexus.seoulmate.chat.domain.entity;
+
+public enum MsgType{
+    TEXT,FILE,SYS
+}

--- a/src/main/java/com/nexus/seoulmate/chat/domain/entity/Role.java
+++ b/src/main/java/com/nexus/seoulmate/chat/domain/entity/Role.java
@@ -1,0 +1,5 @@
+package com.nexus.seoulmate.chat.domain.entity;
+
+public enum Role {
+    OWNER, PARTICIPANT
+}

--- a/src/main/java/com/nexus/seoulmate/chat/domain/entity/RoomType.java
+++ b/src/main/java/com/nexus/seoulmate/chat/domain/entity/RoomType.java
@@ -1,0 +1,5 @@
+package com.nexus.seoulmate.chat.domain.entity;
+
+public enum RoomType {
+    DIRECT,GROUP
+}

--- a/src/main/java/com/nexus/seoulmate/chat/domain/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/nexus/seoulmate/chat/domain/repository/ChatRoomMemberRepository.java
@@ -1,0 +1,24 @@
+package com.nexus.seoulmate.chat.domain.repository;
+
+import com.nexus.seoulmate.chat.domain.entity.ChatRoomMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, Long> {
+
+    @Query("select (count(m) > 0) from ChatRoomMember m where m.roomId = :roomId and m.userId = :userId")
+    boolean existsByRoomIdAndUserId(Long roomId, Long userId);
+
+    @Query("""
+        select m from ChatRoomMember m
+        where m.roomId in :roomIds
+    """)
+    List<ChatRoomMember> findByRoomIdIn(Collection<Long> roomIds);
+
+    @Query("select m from ChatRoomMember m where m.roomId = :roomId")
+    List<ChatRoomMember> findByRoomId(Long roomId);
+}

--- a/src/main/java/com/nexus/seoulmate/chat/domain/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/nexus/seoulmate/chat/domain/repository/ChatRoomMemberRepository.java
@@ -21,4 +21,5 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
 
     @Query("select m from ChatRoomMember m where m.roomId = :roomId")
     List<ChatRoomMember> findByRoomId(Long roomId);
+
 }

--- a/src/main/java/com/nexus/seoulmate/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/nexus/seoulmate/chat/domain/repository/ChatRoomRepository.java
@@ -25,4 +25,5 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     """)
     Page<ChatRoom> findMyRoomsOrderByLatestMessage(Long userId, RoomType type, Pageable pageable);
 
+    Optional<ChatRoom> findByMeetingIdAndType(Long meetingId, RoomType type);
 }

--- a/src/main/java/com/nexus/seoulmate/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/nexus/seoulmate/chat/domain/repository/ChatRoomRepository.java
@@ -1,0 +1,28 @@
+package com.nexus.seoulmate.chat.domain.repository;
+
+import com.nexus.seoulmate.chat.domain.entity.ChatRoom;
+import com.nexus.seoulmate.chat.domain.entity.ChatRoomMember;
+import com.nexus.seoulmate.chat.domain.entity.RoomType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    @Query("""
+       select r from ChatRoom r
+       join ChatRoomMember m on r.id = m.roomId
+       left join Message msg on r.id = msg.roomId
+       where m.userId = :userId
+         and (:type is null or r.type = :type)
+       group by r
+       order by coalesce(max(msg.createdAt), r.createdAt) desc
+    """)
+    Page<ChatRoom> findMyRoomsOrderByLatestMessage(Long userId, RoomType type, Pageable pageable);
+
+}

--- a/src/main/java/com/nexus/seoulmate/chat/domain/repository/MessageRepository.java
+++ b/src/main/java/com/nexus/seoulmate/chat/domain/repository/MessageRepository.java
@@ -1,0 +1,35 @@
+package com.nexus.seoulmate.chat.domain.repository;
+
+import com.nexus.seoulmate.chat.domain.entity.Message;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface MessageRepository extends JpaRepository <Message,Long> {
+    @Query("""
+        select m from Message m
+        where m.roomId in :roomIds
+          and m.id in (
+            select max(m2.id) from Message m2
+            where m2.roomId in :roomIds
+            group by m2.roomId
+          )
+    """)
+    List<Message> findLatestByRoomIds(Collection<Long> roomIds);
+
+    @Query("""
+        select m from Message m
+        where m.roomId = :roomId
+          and (:cursorId is null or m.id < :cursorId)
+        order by m.id desc
+    """)
+    List<Message> findRecent(@Param("roomId") Long roomId,
+                             @Param("cursorId") Long cursorId,
+                             Pageable pageable);
+
+    boolean existsByRoomIdAndIdLessThan(Long roomId, Long id);
+}

--- a/src/main/java/com/nexus/seoulmate/chat/dto/ChatRoomDTO.java
+++ b/src/main/java/com/nexus/seoulmate/chat/dto/ChatRoomDTO.java
@@ -1,0 +1,87 @@
+package com.nexus.seoulmate.chat.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ChatRoomDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DirectCreateRequest {
+        private Long partnerUserId;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RoomSummary {
+        private Long roomId;
+        private String title;
+        private String roomImageUrl;
+        private String type; // "DIRECT" | "GROUP"
+        private Long myUserId;
+
+        private List<Participant> participants;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GroupCreateRequest {
+        private Long meetingId;
+        private List<Long> memberUserIds;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RoomListItem {
+        private Long roomId;
+        private String type;
+        private String title;
+        private String roomImageUrl;
+
+        // DIRECT 전용
+        private Long partnerUserId;       // 그룹이면 null
+
+        private String lastMessageType;
+        private String lastMessage;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime lastMessageAt;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Participant {
+        private Long userId;
+        private String name;
+        private String profileImageUrl;
+        private String role;
+        private boolean me;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RoomHeader {
+        private Long roomId;
+        private String type;
+        private String title;
+        private String roomImageUrl;
+        private List<Participant> participants;
+    }
+}

--- a/src/main/java/com/nexus/seoulmate/chat/dto/ChatRoomDTO.java
+++ b/src/main/java/com/nexus/seoulmate/chat/dto/ChatRoomDTO.java
@@ -84,4 +84,12 @@ public class ChatRoomDTO {
         private String roomImageUrl;
         private List<Participant> participants;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class GroupJoinRequest {
+        private Long meetingId;
+    }
 }

--- a/src/main/java/com/nexus/seoulmate/chat/dto/MessageDTO.java
+++ b/src/main/java/com/nexus/seoulmate/chat/dto/MessageDTO.java
@@ -1,0 +1,66 @@
+package com.nexus.seoulmate.chat.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.nexus.seoulmate.chat.domain.entity.MsgType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class MessageDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SendRequest {
+        private MsgType type;
+        private String content;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Sent {
+        private Long messageId;
+        private Long roomId;
+        private Long senderId;
+        private String senderName;
+        private String type;
+        private String content;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MessageItem {
+        private Long messageId;
+        private Long roomId;
+        private Long senderId;
+        private String senderName;
+        private String senderProfileImageUrl;
+        private String type;
+        private String content;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime createdAt;
+        private boolean mine;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Page {
+        private List<MessageItem> items;
+        private Long nextCursor;
+        private boolean hasMore;
+    }
+
+}

--- a/src/main/java/com/nexus/seoulmate/chat/event/AsyncConfig.java
+++ b/src/main/java/com/nexus/seoulmate/chat/event/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.nexus.seoulmate.chat.event;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean
+    public Executor taskExecutor() {
+        var ex = new ThreadPoolTaskExecutor();
+        ex.setCorePoolSize(4);
+        ex.setMaxPoolSize(16);
+        ex.setQueueCapacity(1000);
+        ex.setThreadNamePrefix("chat-async-");
+        ex.initialize();
+        return ex;
+    }
+}

--- a/src/main/java/com/nexus/seoulmate/chat/event/ChatEvents.java
+++ b/src/main/java/com/nexus/seoulmate/chat/event/ChatEvents.java
@@ -1,0 +1,7 @@
+package com.nexus.seoulmate.chat.event;
+
+import com.nexus.seoulmate.chat.dto.MessageDTO;
+
+public class ChatEvents {
+    public record MessageSaved(Long roomId, MessageDTO.Sent payload) {}
+}

--- a/src/main/java/com/nexus/seoulmate/chat/event/ChatMessageEventHandler.java
+++ b/src/main/java/com/nexus/seoulmate/chat/event/ChatMessageEventHandler.java
@@ -1,0 +1,20 @@
+package com.nexus.seoulmate.chat.event;
+
+import com.nexus.seoulmate.chat.redis.ChatPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ChatMessageEventHandler {
+    private final ChatPublisher chatPublisher;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onMessageSaved(ChatEvents.MessageSaved e) {
+        chatPublisher.publishToRoom(e.roomId(), e.payload());
+    }
+}

--- a/src/main/java/com/nexus/seoulmate/chat/redis/ChatPublisher.java
+++ b/src/main/java/com/nexus/seoulmate/chat/redis/ChatPublisher.java
@@ -1,0 +1,23 @@
+package com.nexus.seoulmate.chat.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexus.seoulmate.chat.dto.MessageDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ChatPublisher {
+    private final StringRedisTemplate rt;
+    private final ObjectMapper om;
+
+    public void publishToRoom(long roomId, MessageDTO.Sent dto) {
+        try {
+            String json = om.writeValueAsString(dto);
+            rt.convertAndSend("room:" + roomId, json);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/nexus/seoulmate/chat/redis/RedisSubscriber.java
+++ b/src/main/java/com/nexus/seoulmate/chat/redis/RedisSubscriber.java
@@ -1,0 +1,33 @@
+package com.nexus.seoulmate.chat.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexus.seoulmate.chat.dto.MessageDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisSubscriber implements MessageListener {
+
+    private final SimpMessagingTemplate template;
+    private final ObjectMapper om;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String channel = new String(message.getChannel());
+            String body    = new String(message.getBody());
+
+            MessageDTO.Sent dto = om.readValue(body, MessageDTO.Sent.class);
+            String roomId = channel.substring("room:".length());
+
+            template.convertAndSend("/topic/room." + roomId, dto);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/nexus/seoulmate/config/RedisConfig.java
+++ b/src/main/java/com/nexus/seoulmate/config/RedisConfig.java
@@ -4,15 +4,38 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.nexus.seoulmate.chat.redis.RedisSubscriber;
+import lombok.AllArgsConstructor;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@AllArgsConstructor
 public class RedisConfig {
+
+    private final RedisConnectionFactory connectionFactory;
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisSubscriber subscriber) {
+        var container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(subscriber, new PatternTopic("room:*"));
+        return container;
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate() {
+        return new StringRedisTemplate(connectionFactory);
+    }
 
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {

--- a/src/main/java/com/nexus/seoulmate/config/WebSocketConfig.java
+++ b/src/main/java/com/nexus/seoulmate/config/WebSocketConfig.java
@@ -1,0 +1,24 @@
+package com.nexus.seoulmate.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry reg) {
+        reg.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry reg) {
+        reg.setApplicationDestinationPrefixes("/app");
+        reg.enableSimpleBroker("/topic", "/queue");
+        reg.setUserDestinationPrefix("/user");
+    }
+}

--- a/src/main/java/com/nexus/seoulmate/exception/status/ErrorStatus.java
+++ b/src/main/java/com/nexus/seoulmate/exception/status/ErrorStatus.java
@@ -57,9 +57,23 @@ public enum ErrorStatus {
     PAYMENT_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT500", "결제 요청 실패"),
     AMOUNT_TAMPERED(HttpStatus.BAD_REQUEST, "PAYMENT400", "결제 금액이 일치하기 않습니다."),
     PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT400", "결제가 실패했습니다."),
-    IAMPORT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT500", "아임포트 API 오류 발생");
+    IAMPORT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT500", "아임포트 API 오류 발생"),
 
     // MyPage
+
+    // Chat
+    CHAT_INVALID_PARTNER(HttpStatus.BAD_REQUEST, "CHAT4001", "유효하지 않은 상대 사용자입니다."),
+    CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT4002", "채팅방을 찾을 수 없습니다."),
+    CHAT_NOT_MEMBER(HttpStatus.FORBIDDEN, "CHAT4003", "해당 채팅방 멤버가 아닙니다."),
+    CHAT_GROUP_MIN_MEMBERS(HttpStatus.BAD_REQUEST, "CHAT4004", "그룹 채팅은 최소 3인 이상이어야 합니다."),
+    CHAT_INVALID_MESSAGE_TYPE(HttpStatus.BAD_REQUEST, "CHAT4005", "유효하지 않은 메시지 타입입니다."),
+    CHAT_SYSTEM_MESSAGE_FORBIDDEN(HttpStatus.FORBIDDEN, "CHAT4006", "시스템 메시지는 전송할 수 없습니다."),
+    CHAT_EMPTY_MESSAGE(HttpStatus.BAD_REQUEST, "CHAT4007", "메시지 내용이 비어 있습니다."),
+    CHAT_FILE_INFO_REQUIRED(HttpStatus.BAD_REQUEST, "CHAT4008", "파일 메시지의 첨부 정보가 필요합니다."),
+    CHAT_MESSAGE_PUBLISH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CHAT4009", "메시지 발행에 실패했습니다."),
+    CHAT_MESSAGE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CHAT4010", "메시지 저장에 실패했습니다."),
+    CHAT_GROUP_MEETING_REQUIRED(HttpStatus.BAD_REQUEST, "CHAT_4002", "그룹 채팅 생성 시 meetingId는 필수입니다."),
+    CHAT_GROUP_MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_4003", "찾을 수 없는 사설모임입니다.");
 
 
 

--- a/src/main/java/com/nexus/seoulmate/exception/status/ErrorStatus.java
+++ b/src/main/java/com/nexus/seoulmate/exception/status/ErrorStatus.java
@@ -72,8 +72,12 @@ public enum ErrorStatus {
     CHAT_FILE_INFO_REQUIRED(HttpStatus.BAD_REQUEST, "CHAT4008", "파일 메시지의 첨부 정보가 필요합니다."),
     CHAT_MESSAGE_PUBLISH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CHAT4009", "메시지 발행에 실패했습니다."),
     CHAT_MESSAGE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CHAT4010", "메시지 저장에 실패했습니다."),
-    CHAT_GROUP_MEETING_REQUIRED(HttpStatus.BAD_REQUEST, "CHAT_4002", "그룹 채팅 생성 시 meetingId는 필수입니다."),
-    CHAT_GROUP_MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_4003", "찾을 수 없는 사설모임입니다.");
+    CHAT_GROUP_MEETING_REQUIRED(HttpStatus.BAD_REQUEST, "CHAT4011", "그룹 채팅 생성 시 meetingId는 필수입니다."),
+    CHAT_GROUP_MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT4012", "찾을 수 없는 사설모임입니다."),
+    CHAT_GROUP_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT4013", "해당 사설모임의 그룹 채팅방이 존재하지 않습니다."),
+    CHAT_GROUP_ALREADY_MEMBER(HttpStatus.BAD_REQUEST, "CHAT4014", "이미 그룹 채팅의 멤버입니다."),
+    CHAT_GROUP_NOT_MEETING_MEMBER(HttpStatus.FORBIDDEN,  "CHAT4015", "사설모임 참가자만 그룹 채팅에 합류할 수 있습니다.");
+
 
 
 

--- a/src/main/java/com/nexus/seoulmate/exception/status/SuccessStatus.java
+++ b/src/main/java/com/nexus/seoulmate/exception/status/SuccessStatus.java
@@ -56,8 +56,14 @@ public enum SuccessStatus {
     PROFILE_IMAGE_UPDATE_SUCCESS(HttpStatus.OK, "MYPAGE 200", "프로필 이미지 수정 성공"),
     PROFILE_BIO_UPDATE_SUCCESS(HttpStatus.OK, "MYPAGE 200", "프로필 한 줄 소개 수정 성공"),
     HOBBY_UPDATE_SUCCESS(HttpStatus.OK, "MYPAGE 200", "취미 수정 성공"),
-    LANGUAGE_LEVEL_UPDATE_SUCCESS(HttpStatus.OK, "MYPAGE 200", "언어 레벨 수정 성공");
+    LANGUAGE_LEVEL_UPDATE_SUCCESS(HttpStatus.OK, "MYPAGE 200", "언어 레벨 수정 성공"),
 
+    // Chat
+    CHAT_ROOM_CREATED(HttpStatus.OK,"CHAT201", "채팅방이 성공적으로 생성되었습니다."),
+    CHAT_ROOM_FETCHED(HttpStatus.OK,"CHAT200", "내 채팅방 목록 조회에 성공했습니다."),
+    CHAT_ROOMS_FETCHED(HttpStatus.OK,"CHAT200", "내 채팅방 목록 조회에 성공했습니다."),
+    CHAT_MESSAGE_SENT(HttpStatus.OK,"CHAT200", "메시지가 성공적으로 전송되었습니다."),
+    CHAT_MESSAGES_FETCHED(HttpStatus.OK,"CHAT200", "채팅 메시지 목록 조회에 성공했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/nexus/seoulmate/exception/status/SuccessStatus.java
+++ b/src/main/java/com/nexus/seoulmate/exception/status/SuccessStatus.java
@@ -63,7 +63,8 @@ public enum SuccessStatus {
     CHAT_ROOM_FETCHED(HttpStatus.OK,"CHAT200", "내 채팅방 목록 조회에 성공했습니다."),
     CHAT_ROOMS_FETCHED(HttpStatus.OK,"CHAT200", "내 채팅방 목록 조회에 성공했습니다."),
     CHAT_MESSAGE_SENT(HttpStatus.OK,"CHAT200", "메시지가 성공적으로 전송되었습니다."),
-    CHAT_MESSAGES_FETCHED(HttpStatus.OK,"CHAT200", "채팅 메시지 목록 조회에 성공했습니다.");
+    CHAT_MESSAGES_FETCHED(HttpStatus.OK,"CHAT200", "채팅 메시지 목록 조회에 성공했습니다."),
+    CHAT_ROOM_JOINED(HttpStatus.OK, "CHAT200", "그룹 채팅방에 합류했습니다.");
 
     private final HttpStatus status;
     private final String code;


### PR DESCRIPTION
### 이슈 번호
- close #58 

### 작업 내용
- POST /chat/room/onetoone → 1:1 채팅방 생성
- POST /chat/room/group → 그룹 채팅방 생성
- POST /chat/group/join → 사설모임 그룹 채팅 합류
- GET /chat/rooms → 내 채팅방 목록 조회
- GET /chat/rooms/{roomId}/messages → 채팅 메시지 조회 (커서 기반)
- POST /chat/rooms/{roomId}/messages → 메시지 전송
- GET /chat/rooms/{roomId}/header → 채팅방 헤더 정보 조회


### 기타
