### PR TITLE
[FIX] 검색 필터 언어별 점수 따로 받기 및 userId getCurrentId 수정

### DIFF
--- a/src/main/java/com/nexus/seoulmate/meeting/api/MeetingPrivateController.java
+++ b/src/main/java/com/nexus/seoulmate/meeting/api/MeetingPrivateController.java
@@ -7,9 +7,11 @@ import com.nexus.seoulmate.meeting.api.dto.request.privateReq.MeetingUpdatePriva
 import com.nexus.seoulmate.meeting.api.dto.response.MeetingDetailPrivateRes;
 import com.nexus.seoulmate.meeting.application.privateMeeting.PrivateMeetingService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -22,33 +24,29 @@ public class MeetingPrivateController {
 
     @Operation(summary = "private 모임 생성 API")
     @PostMapping
-    public ResponseEntity<Response<Long>> createMeeting(@RequestBody MeetingCreatePrivateReq req,
-                                                  @RequestHeader("userId") Long userId){
+    public ResponseEntity<Response<Long>> createMeeting(@RequestBody MeetingCreatePrivateReq req){
         return ResponseEntity
                 .status(SuccessStatus.CREATE_MEETING.getStatus())
-                .body(privateMeetingService.createMeeting(req, userId));
+                .body(privateMeetingService.createMeeting(req));
     }
 
     @Operation(summary = "private 모임 상세 조회 API")
     @GetMapping("/{meetingId}")
-    public ResponseEntity<Response<MeetingDetailPrivateRes>> getPrivateMeetingDetail(@PathVariable Long meetingId,
-                                                                           @RequestHeader("userId") Long userId){
-        return ResponseEntity.ok(privateMeetingService.getPrivateMeetingDetail(meetingId, userId));
+    public ResponseEntity<Response<MeetingDetailPrivateRes>> getPrivateMeetingDetail(@PathVariable Long meetingId){
+        return ResponseEntity.ok(privateMeetingService.getPrivateMeetingDetail(meetingId));
     }
 
     @Operation(summary = "private 모임 수정 API")
     @PutMapping("/{meetingId}")
     public ResponseEntity<Response<Long>> updateMeeting(@PathVariable Long meetingId,
-                                                    @RequestBody MeetingUpdatePrivateReq req,
-                                                    @RequestHeader("userId") Long userId){
-        return ResponseEntity.ok(privateMeetingService.updateMeeting(meetingId, req, userId));
+                                                    @RequestBody MeetingUpdatePrivateReq req){
+        return ResponseEntity.ok(privateMeetingService.updateMeeting(meetingId, req));
     }
 
     @Operation(summary = "private 모임 삭제 API")
     @DeleteMapping("/{meetingId}")
-    public ResponseEntity<Response<Long>> deleteMeeting(@PathVariable Long meetingId,
-                                                    @RequestHeader("userId") Long userId){
-        return ResponseEntity.ok(privateMeetingService.deleteMeeting(meetingId, userId));
+    public ResponseEntity<Response<Long>> deleteMeeting(@PathVariable Long meetingId){
+        return ResponseEntity.ok(privateMeetingService.deleteMeeting(meetingId));
     }
 
 }

--- a/src/main/java/com/nexus/seoulmate/meeting/api/dto/request/MeetingSearchReq.java
+++ b/src/main/java/com/nexus/seoulmate/meeting/api/dto/request/MeetingSearchReq.java
@@ -3,8 +3,6 @@ package com.nexus.seoulmate.meeting.api.dto.request;
 import com.nexus.seoulmate.member.domain.enums.HobbyCategory;
 import com.nexus.seoulmate.member.domain.enums.Languages;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 public record MeetingSearchReq(
         @Schema(description = "상위 카테고리", example = "스포츠")
@@ -16,11 +14,16 @@ public record MeetingSearchReq(
         @Schema(description = "언어", example = "한국어")
         Languages language, // 특정 언어 필터
 
-        @Schema(description = "언어 레벨 최솟값", example = "40")
-        Integer minLevel, // 언어 레벨 0~100
+        // 언어 레벨 0~100
+        @Schema(description = "한국어 레벨 최솟값", example = "40")
+        Integer koMinLevel,
+        @Schema(description = "한국어 레벨 최대값", example = "80")
+        Integer koMaxLevel,
 
-        @Schema(description = "언어 레벨 최대값", example = "80")
-        Integer maxLevel,
+        @Schema(description = "영어 레벨 최솟값", example = "40")
+        Integer enMinLevel,
+        @Schema(description = "영어 레벨 최대값", example = "80")
+        Integer enMaxLevel,
 
         @Schema(description = "페이지 번호(0부터)", example = "0")
         Integer page,
@@ -29,9 +32,44 @@ public record MeetingSearchReq(
         Integer size
 ) {
 
+    private int clamp(Integer v, int low, int high, int def) {
+        int x = (v == null ? def : v);
+        return Math.max(low, Math.min(high, x));
+    }
+
+    // 페이징
     public int pageDefault() { return page == null || page < 0 ? 0 : page; }
     public int sizeDefault() { return size == null || size < 1 ? 20 : size; }
 
-    public int minLevelDefault() { return minLevel == null ? 0 : Math.max(0, Math.min(100, minLevel)); }
-    public int maxLevelDefault() { return maxLevel == null ? 100 : Math.max(0, Math.min(100, maxLevel)); }
+    // 언어별 레벨 기본값
+    public int koMinDefault() { return clamp(koMinLevel, 0, 100, 0); }
+    public int koMaxDefault() { return clamp(koMaxLevel, 0, 100, 100); }
+    public int enMinDefault() { return clamp(enMinLevel, 0, 100, 0); }
+    public int enMaxDefault() { return clamp(enMaxLevel, 0, 100, 100); }
+
+    public boolean koreanSelected()  { return language != null && language == Languages.KOREAN; }
+    public boolean englishSelected() { return language != null && language == Languages.ENGLISH; }
+    public boolean languageNotSelected() { return language == null; }
+
+    // 선택 언어만 필터로, 반대 언어 값 무시
+    public MeetingSearchReq normalized(){
+        if(koreanSelected()){
+            return new MeetingSearchReq(
+                    hobbyCategory, keyword, language,
+                    koMinLevel, koMaxLevel,
+                    null, null,
+                    page, size
+            );
+        }
+        if(englishSelected()){
+            return new MeetingSearchReq(
+                    hobbyCategory, keyword, language,
+                    null, null,
+                    enMinLevel, enMaxLevel,
+                    page, size
+            );
+        }
+        // 언어 미선택 -> 둘 다 유지
+        return this;
+    }
 }

--- a/src/main/java/com/nexus/seoulmate/meeting/application/privateMeeting/PrivateMeetingService.java
+++ b/src/main/java/com/nexus/seoulmate/meeting/application/privateMeeting/PrivateMeetingService.java
@@ -6,8 +6,8 @@ import com.nexus.seoulmate.meeting.api.dto.request.privateReq.MeetingUpdatePriva
 import com.nexus.seoulmate.meeting.api.dto.response.MeetingDetailPrivateRes;
 
 public interface PrivateMeetingService {
-    Response<Long> createMeeting(MeetingCreatePrivateReq req, Long userId);
-    Response<MeetingDetailPrivateRes> getPrivateMeetingDetail(Long id, Long userId);
-    Response<Long> updateMeeting(Long meetingId, MeetingUpdatePrivateReq req, Long userId);
-    Response<Long> deleteMeeting(Long meetingId, Long userId);
+    Response<Long> createMeeting(MeetingCreatePrivateReq req);
+    Response<MeetingDetailPrivateRes> getPrivateMeetingDetail(Long id);
+    Response<Long> updateMeeting(Long meetingId, MeetingUpdatePrivateReq req);
+    Response<Long> deleteMeeting(Long meetingId);
 }

--- a/src/main/java/com/nexus/seoulmate/meeting/application/privateMeeting/PrivateMeetingServiceImpl.java
+++ b/src/main/java/com/nexus/seoulmate/meeting/application/privateMeeting/PrivateMeetingServiceImpl.java
@@ -6,7 +6,6 @@ import com.nexus.seoulmate.member.domain.enums.HobbyCategory;
 import com.nexus.seoulmate.member.domain.enums.Languages;
 import com.nexus.seoulmate.member.domain.enums.Role;
 import com.nexus.seoulmate.member.repository.HobbyRepository;
-import com.nexus.seoulmate.member.repository.MemberRepository;
 import com.nexus.seoulmate.exception.CustomException;
 import com.nexus.seoulmate.exception.Response;
 import com.nexus.seoulmate.exception.status.ErrorStatus;
@@ -17,6 +16,8 @@ import com.nexus.seoulmate.meeting.api.dto.response.MeetingDetailPrivateRes;
 import com.nexus.seoulmate.meeting.domain.Meeting;
 import com.nexus.seoulmate.meeting.domain.MeetingType;
 import com.nexus.seoulmate.meeting.domain.repository.MeetingRepository;
+import com.nexus.seoulmate.member.repository.MemberRepository;
+import com.nexus.seoulmate.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,11 +33,12 @@ import java.util.regex.Pattern;
 public class PrivateMeetingServiceImpl implements PrivateMeetingService {
 
     private final MeetingRepository meetingRepository;
-    private final MemberRepository memberRepository;
     private final HobbyRepository hobbyRepository;
+    private final MemberService memberService;
 
     // 숫자 문자열 검증
     private static final Pattern NUMERIC = Pattern.compile("^\\d+$");
+    private final MemberRepository memberRepository;
 
     private int parsePositiveInt(String raw, String fieldName){
         if(raw == null){
@@ -67,9 +69,9 @@ public class PrivateMeetingServiceImpl implements PrivateMeetingService {
 
     @Override
     @Transactional
-    public Response<Long> createMeeting(MeetingCreatePrivateReq req, Long userId) {
-        Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
+    public Response<Long> createMeeting(MeetingCreatePrivateReq req) {
+        Long userId = memberService.getCurrentId();
+        Member member = memberRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
 
         if (member.getRole() == Role.ADMIN) {
             throw new CustomException(ErrorStatus.INVALID_MEETING_TYPE); // ADMIN은 private 생성 불가
@@ -78,7 +80,6 @@ public class PrivateMeetingServiceImpl implements PrivateMeetingService {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH);
         LocalDate meetingDay = LocalDate.parse(req.meeting_day(), formatter);
         LocalTime startTime = LocalTime.parse(req.start_time());
-
 
         // 세부 취미 조회
         String raw = req.primaryHobbyName();
@@ -129,7 +130,7 @@ public class PrivateMeetingServiceImpl implements PrivateMeetingService {
     }
 
     @Transactional(readOnly = true)
-    public Response<MeetingDetailPrivateRes> getPrivateMeetingDetail(Long meetingId, Long userId) {
+    public Response<MeetingDetailPrivateRes> getPrivateMeetingDetail(Long meetingId) {
         Meeting meeting = meetingRepository.findWithUserById(meetingId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.MEETING_NOT_FOUND));
 
@@ -166,11 +167,12 @@ public class PrivateMeetingServiceImpl implements PrivateMeetingService {
     }
     @Override
     @Transactional
-    public Response<Long> updateMeeting(Long meetingId, MeetingUpdatePrivateReq req, Long userId) {
+    public Response<Long> updateMeeting(Long meetingId, MeetingUpdatePrivateReq req) {
         Meeting meeting = meetingRepository.findWithUserById(meetingId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.MEETING_NOT_FOUND));
 
-        if (!meeting.getUserId().getUserId().equals(userId)) {
+        Long meId = memberService.getCurrentId();
+        if (!meeting.getUserId().getUserId().equals(meId)) {
             throw new CustomException(ErrorStatus.FORBIDDEN);
         }
 
@@ -229,11 +231,12 @@ public class PrivateMeetingServiceImpl implements PrivateMeetingService {
 
     @Override
     @Transactional
-    public Response<Long> deleteMeeting(Long meetingId, Long userId) {
+    public Response<Long> deleteMeeting(Long meetingId) {
         Meeting meeting = meetingRepository.findWithUserById(meetingId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.MEETING_NOT_FOUND));
 
-        if (!meeting.getUserId().getUserId().equals(userId)) {
+        Long meId = memberService.getCurrentId();
+        if (!meeting.getUserId().getUserId().equals(meId)) {
             throw new CustomException(ErrorStatus.FORBIDDEN);
         }
 

--- a/src/main/java/com/nexus/seoulmate/meeting/application/search/MeetingSearchServiceImpl.java
+++ b/src/main/java/com/nexus/seoulmate/meeting/application/search/MeetingSearchServiceImpl.java
@@ -1,7 +1,5 @@
 package com.nexus.seoulmate.meeting.application.search;
 
-import com.nexus.seoulmate.exception.CustomException;
-import com.nexus.seoulmate.exception.status.ErrorStatus;
 import com.nexus.seoulmate.meeting.api.dto.request.MeetingSearchReq;
 import com.nexus.seoulmate.meeting.api.dto.response.MeetingListRes;
 import com.nexus.seoulmate.meeting.domain.Meeting;
@@ -19,7 +17,10 @@ public class MeetingSearchServiceImpl implements MeetingSearchService{
 
     @Override
     public List<MeetingListRes> searchMeetings(MeetingSearchReq req){
-        List<Meeting> meetings = meetingRepository.findBySearchCondition(req);
+        // 선택 언어만 남기고 반대 언어 값 제거
+        MeetingSearchReq r = req.normalized();
+
+        List<Meeting> meetings = meetingRepository.findBySearchCondition(r);
 
         return meetings.stream()
                 .map(m -> new MeetingListRes(

--- a/src/main/java/com/nexus/seoulmate/member/service/MemberService.java
+++ b/src/main/java/com/nexus/seoulmate/member/service/MemberService.java
@@ -170,6 +170,12 @@ public class MemberService {
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
     }
 
+    // 현재 로그인한 사용자의 userId만 반환
+    public Long getCurrentId() {
+        return getCurrentUser().getUserId();
+    }
+
+
     // 현재 로그인한 사용자의 이메일 가져오기
     public String getCurrentUserEmail() {
         var auth = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/com/nexus/seoulmate/notification/api/NotificationController.java
+++ b/src/main/java/com/nexus/seoulmate/notification/api/NotificationController.java
@@ -6,14 +6,22 @@ import com.nexus.seoulmate.notification.api.dto.response.NotificationRes;
 import com.nexus.seoulmate.notification.application.NotificationPushService;
 import com.nexus.seoulmate.notification.application.NotificationService;
 import com.nexus.seoulmate.notification.domain.LinkTargetType;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.Set;
+import java.util.stream.Collectors;
 
 
 @RestController
@@ -25,34 +33,41 @@ public class NotificationController {
     private final NotificationPushService notificationPushService;
     private final NotificationService notificationService;
 
+    private static final Set<String> ALLOWED_SORTS = Set.of("createdAt", "id", "title", "updatedAt", "isRead");
+
     // SSE 구독
     @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter stream(@RequestHeader("userId") Long userId){
-        // 로그 코드 추가
-        log.info("[SSE] subscribe request userId={}", userId);
-
-        return notificationPushService.subscribe(userId);
+    public SseEmitter stream(){
+        return notificationPushService.subscribeForCurrentUser();
     }
 
     // 내 알림 목록 조회
     @GetMapping("/me")
     public ResponseEntity<Response<Page<NotificationRes>>> getMyNotifications(
-            @RequestHeader("userId") Long userId,
             @RequestParam(value = "type", required = false)LinkTargetType type,
-            Pageable pageable
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
             ){
+
+        // 정렬 조건 검사
+        Sort whitelisted = pageable.getSort().stream()
+                .filter(o -> ALLOWED_SORTS.contains(o.getProperty()))
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toList(),
+                        list -> list.isEmpty() ? Sort.by(Sort.Direction.DESC, "createdAt") : Sort.by(list)
+                ));
+
+        Pageable safePageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), whitelisted);
+
         // type이 null 이면 디폴트로 모임으로 처리
-        Page<NotificationRes> page = notificationService.findAll(userId, type, pageable);
+        Page<NotificationRes> page = notificationService.findAllForCurrentUser(type, safePageable);
         return ResponseEntity.ok(Response.success(SuccessStatus.NOTIFICATION_LIST_OK, page));
     }
 
     // 알림 읽음 처리
     @PostMapping("/{notificationId}/read")
-    public ResponseEntity<Response<Void>> markRead(
-            @RequestHeader("userId") Long userId,
-            @PathVariable Long notificationId
+    public ResponseEntity<Response<Void>> markRead(@PathVariable Long notificationId
     ){
-        notificationService.markRead(userId, notificationId);
+        notificationService.markReadForCurrentUser(notificationId);
         return ResponseEntity.ok(Response.success(SuccessStatus.NOTIFICATION_READ_OK, null));
     }
 }

--- a/src/main/java/com/nexus/seoulmate/notification/application/NotificationPushService.java
+++ b/src/main/java/com/nexus/seoulmate/notification/application/NotificationPushService.java
@@ -1,6 +1,8 @@
 package com.nexus.seoulmate.notification.application;
 
+import com.nexus.seoulmate.member.service.MemberService;
 import com.nexus.seoulmate.notification.api.dto.NotificationPushDto;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -14,10 +16,18 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class NotificationPushService {
 
     private static final long TIMEOUT_MS = 0L; //  무제한
     private final Map<Long, Set<SseEmitter>> emitters = new ConcurrentHashMap<>();
+
+    private final MemberService memberService;
+
+    public SseEmitter subscribeForCurrentUser() {
+        Long userId = memberService.getCurrentId();
+        return subscribe(userId);
+    }
 
     // 클라이언트가 /notifications/stream으로 접속
     public SseEmitter subscribe(Long userId) {
@@ -26,18 +36,23 @@ public class NotificationPushService {
         emitters.computeIfAbsent(userId, k -> ConcurrentHashMap.newKeySet()).add(emitter);
 
         // 로그 코드 추가
-        log.info(" [SSE-구독] userId={} SSE 연결 요청", userId);
+        log.info("[SSE-구독] userId={} SSE 연결 요청", userId);
         try { emitter.send(SseEmitter.event().name("init").data("connected")); } catch (IOException ignored) {}
-        emitter.onCompletion(() -> System.out.println("[SSE] onCompletion userId=" + userId));
-        emitter.onTimeout(() -> System.out.println("[SSE] onTimeout userId=" + userId));
-        emitter.onError(e -> System.out.println("[SSE] onError userId=" + userId + " " + e));
 
-        // 연결 종료, 타임아웃, 에러 시 정리
-        emitter.onCompletion(() -> remove(userId, emitter));
-        emitter.onTimeout(() -> remove(userId, emitter));
-        emitter.onError(e -> remove(userId, emitter));
+        emitter.onCompletion(() -> {
+            log.info("[SSE] onCompletion userId={}", userId);
+            remove(userId, emitter);
+        });
+        emitter.onTimeout(() -> {
+            log.info("[SSE] onTimeout userId={}", userId);
+            remove(userId, emitter);
+        });
+        emitter.onError(e -> {
+            log.warn("[SSE] onError userId={} {} - {}", userId, e.getClass().getSimpleName(), e.getMessage());
+            remove(userId, emitter);
+        });
 
-        log.info(" [SSE-구독완료] userId={} SSE emitter 등록 완료", userId);
+        log.info("[SSE-구독완료] userId={} SSE emitter 등록 완료", userId);
         return emitter;
     }
 

--- a/src/main/java/com/nexus/seoulmate/notification/application/NotificationService.java
+++ b/src/main/java/com/nexus/seoulmate/notification/application/NotificationService.java
@@ -2,6 +2,7 @@ package com.nexus.seoulmate.notification.application;
 
 import com.nexus.seoulmate.exception.CustomException;
 import com.nexus.seoulmate.exception.status.ErrorStatus;
+import com.nexus.seoulmate.member.service.MemberService;
 import com.nexus.seoulmate.notification.api.dto.response.NotificationRes;
 import com.nexus.seoulmate.notification.domain.LinkTargetType;
 import com.nexus.seoulmate.notification.domain.Notification;
@@ -18,10 +19,12 @@ public class NotificationService {
 
     private final NotificationRepository notificationRepository;
     private final NotificationPushService notificationPushService;
+    private final MemberService memberService;
 
     // 내 알림 목록 (최신순)
     @Transactional(readOnly = true)
-    public Page<NotificationRes> findAll(Long receiverId, LinkTargetType type, Pageable pageable) {
+    public Page<NotificationRes> findAllForCurrentUser(LinkTargetType type, Pageable pageable) {
+        Long receiverId = memberService.getCurrentId();
         LinkTargetType linkTargetType = (type == null) ? LinkTargetType.MEETING : type;
         return notificationRepository.findByReceiverAndType(receiverId, linkTargetType, pageable)
                 .map(n -> new NotificationRes(
@@ -39,7 +42,8 @@ public class NotificationService {
 
     // 읽음 처리 + 다른 탭 이벤트 동기화
     @Transactional
-    public void markRead(Long receiverId, Long notificationId) {
+    public void markReadForCurrentUser(Long notificationId) {
+        Long receiverId = memberService.getCurrentId();
         // 알림 존재 확인
         Notification n = notificationRepository.findByIdAndReceiverId(notificationId, receiverId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.NOTIFICATION_NOT_FOUND));

--- a/src/main/java/com/nexus/seoulmate/order/api/OrderController.java
+++ b/src/main/java/com/nexus/seoulmate/order/api/OrderController.java
@@ -24,10 +24,8 @@ public class OrderController {
     @Operation(summary = "주문 생성 API")
     @PostMapping("/{meetingId}")
     public ResponseEntity<Response<CreateOrderResDto>> createOrder(
-            @PathVariable Long meetingId,
-            @RequestHeader("userId") Long userId // 로그인 구현 후 수정 예정
-    ){
-        Order order = orderService.createOrder(meetingId, userId);
+            @PathVariable Long meetingId){
+        Order order = orderService.createOrder(meetingId);
         CreateOrderResDto resDto = new CreateOrderResDto(
                 order.getOrderUid(),
                 order.getMerchantUid(),

--- a/src/main/java/com/nexus/seoulmate/order/application/OrderService.java
+++ b/src/main/java/com/nexus/seoulmate/order/application/OrderService.java
@@ -6,6 +6,7 @@ import com.nexus.seoulmate.meeting.domain.Meeting;
 import com.nexus.seoulmate.meeting.domain.repository.MeetingRepository;
 import com.nexus.seoulmate.member.domain.Member;
 import com.nexus.seoulmate.member.repository.MemberRepository;
+import com.nexus.seoulmate.member.service.MemberService;
 import com.nexus.seoulmate.order.domain.Order;
 import com.nexus.seoulmate.order.domain.OrderStatus;
 import com.nexus.seoulmate.order.domain.repository.OrderRepository;
@@ -19,10 +20,12 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final MeetingRepository meetingRepository;
     private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
-    public Order createOrder(Long meetingId, Long userId) {
-        Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
+    public Order createOrder(Long meetingId) {
+
+        Long userId = memberService.getCurrentId();
+        Member member = memberRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorStatus.MEMBER_NOT_FOUND));
 
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.MEETING_NOT_FOUND));


### PR DESCRIPTION
### 이슈 번호
> 

### 작업 내용
* 검색 필터 언어별 점수 따로 받기
* 알림, 사설모임, 주문 userId getCurrentId로 수정


### 기타
